### PR TITLE
If HOST envvar is not set, use config.autoname

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,7 @@ const errorPublishMissing =
 
 function init(sbot: any, config: any) {
   let aboutMsg: any = null;
-  const hostname = process.env.HOST;
+  const hostname = process.env.HOST || config.autoname;
   if (!hostname) return debug(errorHostnameMissing);
   if (!sbot.whoami) return debug(errorWhoamiMissing);
   if (!sbot.publish) return debug(errorPublishMissing);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/node": "^9.4.6",
     "ts-node": "^4.1.0",
     "typescript": "^2.7.2",
-    "scuttle-testbot": "1.1.6",
+    "scuttle-testbot": "^1.1.6",
     "ssb-keys": "^7.0.14",
     "tape": "4.9.0"
   },


### PR DESCRIPTION
Hi @staltz I have a use case for specifying the desired name in the config. Ok for you?